### PR TITLE
Special treatment for only 2 players without observers or such

### DIFF
--- a/news/another_wrong_detection.rst
+++ b/news/another_wrong_detection.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed detection of the correct winner in another edge case when only 2 players and no observers are involved.
+
+**Security:**
+
+* <news item>

--- a/w3g.py
+++ b/w3g.py
@@ -2448,6 +2448,8 @@ class File(object):
         # compute inc
         if self._lastleft is None:
             inc = False
+        elif self._lastleft is not None and (len(self.players) <=2):
+            inc = True
         else:
             inc = (unknownflag == (self._lastleft.unknownflag + 1))
         # compute closedby and reult


### PR DESCRIPTION
Hey @scopatz 👋 

We have just hit another replay where the winner detection got wrong. You can find that replay here:

https://creepcamp.de/media/replays/RBTV%20Liga%20Season%207/Liga%204%20E/IHartmanI_vs_ENA1337_Echo_Isles.w3g

After further debugging, I see this is related to the Inc value you calculate. Given some further analysis, to me as a newbie of that format, it looks like the Inc value is especially important in cases with observers.

That being said, I added another check for only a case with 2 players and without observers. In that case, the replay parses correct.

I also tested it locally with a couple of other replays and various settings. I couldn't find a regression, however, I`d really like your pair of 👁️  on it.

LMK if there is something more I can do.